### PR TITLE
make install work from the top and hit the bindir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 # Makefile for mercury
 #
 
-.PHONY: mercury test
+.PHONY: mercury test install
 mercury:
 ifneq ($(wildcard src/Makefile), src/Makefile)
 	@echo "error: run ./configure before running make (src/Makefile is missing)"
 else
 	cd src && $(MAKE)
+endif
+
+install:
+ifneq ($(wildcard src/Makefile), src/Makefile)
+	@echo "error: run ./configure before running make (src/Makefile is missing)"
+else
+	cd src && $(MAKE) install
 endif
 
 test:

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -9,7 +9,9 @@ INSTALL = /usr/bin/install -c
 INSTALLDATA = /usr/bin/install -c -m 644
 
 DESTDIR =
-PREFIX = /usr/local
+prefix = @prefix@
+exec_prefix=@exec_prefix@
+bindir = @bindir@
 
 .SUFFIXES:
 .SUFFIXES: .c .o
@@ -95,7 +97,8 @@ distclean: clean
 
 .PHONY: install
 install: mercury
-	$(INSTALL) mercury $(DESTDIR)$(PREFIX)/bin/
+	mkdir -p $(DESTDIR)$(bindir)
+	$(INSTALL) mercury $(DESTDIR)$(bindir)
 
 .PHONY: gprof
 gprof:


### PR DESCRIPTION
This patch changes the makefiles to install to the right location based on the --prefix and other settings from configure.  It also makes sure the directory exists.