### PR TITLE
added support for ./pmercury in osx using gzcat instead of zcat

### DIFF
--- a/python/pmercury/protocols/tcp.py
+++ b/python/pmercury/protocols/tcp.py
@@ -37,7 +37,8 @@ class TCP():
                 fp_['os_info'] = self.clean_os_entry(fp_['os_info'])
                 self.fp_db[fp_['str_repr']] = fp_
         else:
-            for line in os.popen('zcat %s' % (fp_database)):
+            cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
+            for line in os.popen(cmd + ' %s' % (fp_database)):
                 fp_ = json.loads(line)
                 fp_['os_info'] = self.clean_os_entry(fp_['os_info'])
                 self.fp_db[fp_['str_repr']] = fp_

--- a/python/pmercury/protocols/tls.py
+++ b/python/pmercury/protocols/tls.py
@@ -51,7 +51,8 @@ class TLS():
         else:
             transition_probs_file = find_resource_path('resources/transition_probs.csv.gz')
             self.transition_probs = {}
-            for line in os.popen('zcat %s' % (transition_probs_file), mode='r', buffering=8192*256):
+            cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
+            for line in os.popen(cmd + ' %s' % (transition_probs_file), mode='r', buffering=8192*256):
                 t_ = line.strip().split(',')
                 if t_[1] not in self.transition_probs:
                     self.transition_probs[t_[1]] = {}
@@ -77,7 +78,8 @@ class TLS():
                 fp_ = json.loads(line_win)
                 self.fp_db[fp_['str_repr']] = fp_
         else:
-            for line in os.popen('zcat %s' % (fp_database), mode='r', buffering=8192*256):
+            cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
+            for line in os.popen(cmd + ' %s' % (fp_database), mode='r', buffering=8192*256):
                 fp_ = json.loads(line)
                 self.fp_db[fp_['str_repr']] = fp_
         if 'malware' not in self.fp_db[fp_['str_repr']]['process_info'][0]:

--- a/python/pmercury/utils/contextual_info.py
+++ b/python/pmercury/utils/contextual_info.py
@@ -32,7 +32,8 @@ if os.name == 'nt':
         tlds.add(line.decode())
 else:
     public_suffix_file_raw = find_resource_path('resources/public_suffix_list.dat.gz')
-    for line in os.popen('zcat %s' % (public_suffix_file_raw)):
+    cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
+    for line in os.popen(cmd + ' %s' % (public_suffix_file_raw)):
         line = line.strip()
         if line.startswith('//') or line == '':
             continue

--- a/python/pmercury/utils/eqv_classes.py
+++ b/python/pmercury/utils/eqv_classes.py
@@ -26,7 +26,8 @@ if os.name == 'nt':
         tlds.add(line.decode())
 else:
     public_suffix_file_raw = find_resource_path('resources/public_suffix_list.dat.gz')
-    for line in os.popen('zcat %s' % (public_suffix_file_raw)):
+    cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
+    for line in os.popen(cmd + ' %s' % (public_suffix_file_raw)):
         line = line.strip()
         if line.startswith('//') or line == '':
             continue

--- a/python/pmercury/utils/tls_utils.py
+++ b/python/pmercury/utils/tls_utils.py
@@ -35,10 +35,11 @@ if os.name == 'nt':
         imp_date_ext_data = json.loads(line)
         break
 else:
-    for line in os.popen('zcat %s' % (imp_date_cs_file)):
+    cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
+    for line in os.popen(cmd + ' %s' % (imp_date_cs_file)):
         imp_date_cs_data = json.loads(line)
         break
-    for line in os.popen('zcat %s' % (imp_date_ext_file)):
+    for line in os.popen(cmd + ' %s' % (imp_date_ext_file)):
         imp_date_ext_data = json.loads(line)
         break
 


### PR DESCRIPTION
Made some minor changes to allow using ./pmercury script on OSX using gzcat instead of zcat since zcat distributed with OSX differs from the linux versions.

Changes are something like:

`    cmd = 'gzcat' if sys.platform == 'darwin' else 'zcat'
    for line in os.popen(cmd + ' %s' % (imp_date_cs_file)):`

Only tested on OSX Mojave 10.14.6