### PR TITLE
simple fix to make supported versions also normalize grease values

### DIFF
--- a/python/pmercury/utils/tls_utils.py
+++ b/python/pmercury/utils/tls_utils.py
@@ -188,7 +188,7 @@ def degrease_ext_data(data, offset, ext_type, ext_length, ext_value):
             else:
                 degreased_ext_value += data[offset+i:offset+i+2]
         return degreased_ext_value
-    elif ext_type == b'002b': # supported_versions
+    elif ext_type == '002b': # supported_versions
         degreased_ext_value += data[offset:offset+1]
         for i in range(1,ext_length,2):
             if len(data) >= offset+i+1 and data[offset+i] in grease_single_int_ and data[offset+i] == data[offset+i+1]:


### PR DESCRIPTION
Noticed that the supported versions grease values weren't normalizing

Supported Version portion of the fingerprint before this PR:
![Screen Shot 2020-06-17 at 4 45 06 PM](https://user-images.githubusercontent.com/16946541/84948570-ea073280-b0b9-11ea-8c2a-63000313b529.png)

After:
![Screen Shot 2020-06-17 at 4 45 55 PM](https://user-images.githubusercontent.com/16946541/84948650-07d49780-b0ba-11ea-8c9b-b0e92f0a483b.png)

This is due to `b'002b' != '002b'`

Not sure if this behavior is different across different OS or python versions
![Screen Shot 2020-06-17 at 4 47 13 PM](https://user-images.githubusercontent.com/16946541/84948841-4407f800-b0ba-11ea-8de7-124f178ad16d.png)

